### PR TITLE
Removed unnecessary code.

### DIFF
--- a/source/HeadsUpDisplay.hx
+++ b/source/HeadsUpDisplay.hx
@@ -122,16 +122,6 @@ class HeadsUpDisplay extends FlxGroup
 	 */
 	
 	public override function update(elapsed:Float):Void
-	{
-		//UPDATES
-		scoreLabel.update(elapsed);
-		timeLabel.update(elapsed);
-		coinIcon.update(elapsed);
-		coinCross.update(elapsed);
-		score.update(elapsed);
-		time.update(elapsed); 
-		coins.update(elapsed);
-		super.update(elapsed);
-		
+	{	
 	}
 }

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -16,9 +16,7 @@ class PlayState extends FlxState
 	
 	override public function create():Void
 	{
-		if (hud == null){
-			hud = new HeadsUpDisplay(0, 0, "MARIO");
-		}
+		hud = new HeadsUpDisplay(0, 0, "MARIO");
 		super.create();
 		
 		player = new Player(50, 50);


### PR DESCRIPTION
No more superfluous updates in HeadsUpDisplay, and every new PlayState object will reconstruct the HUD.