### PR TITLE
Added player hit-boxes

### DIFF
--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -5,6 +5,7 @@ import flixel.FlxState;
 import flixel.graphics.FlxGraphic;
 import flixel.tile.FlxTilemap;
 import flixel.util.FlxColor;
+import flixel.group.FlxGroup;
 
 class PlayState extends FlxState
 {

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -9,21 +9,22 @@ import flixel.util.FlxColor;
 class PlayState extends FlxState
 {
 	public var GRAVITY(default, never):Float = 600;
-	
+
 	private var map:FlxTilemap;
 	private var player:Player;
 	public static var hud:HeadsUpDisplay;
-	
+
 	override public function create():Void
 	{
 		if (hud == null){
 			hud = new HeadsUpDisplay(0, 0, "MARIO");
 		}
 		super.create();
-		
+
 		player = new Player(50, 50);
 		add(player);
-		
+		add(player.hitBoxComponents);
+
 		map = new FlxTilemap();
 		map.loadMapFromArray([
 			1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,

--- a/source/Player.hx
+++ b/source/Player.hx
@@ -44,13 +44,6 @@ import flixel.group.FlxGroup;
 	{
 		super(X, Y, SimpleGraphic);
 
-    // Multiple hitbox support
-    hitBoxComponents = new FlxTypedGroup<FlxObject>(2);
-    topBox = new FlxObject(X + 1, Y, width - 2, 3);
-    btmBox = new FlxObject(X + 1, Y + height - 4, width - 2, 3);
-    hitBoxComponents.add(topBox);
-    hitBoxComponents.add(btmBox);
-
 		// Initializes a basic graphic for the player
 		makeGraphic(32, 32, FlxColor.ORANGE);
 
@@ -63,6 +56,13 @@ import flixel.group.FlxGroup;
 
 		// Initialize the finite-state machine with initial state
 		brain = new FSM( new PlayerAirState() );
+
+    // Multiple hitbox support
+    hitBoxComponents = new FlxTypedGroup<FlxObject>(2);
+    topBox = new FlxObject(X + 1, Y, width - 2, 3);
+    btmBox = new FlxObject(X + 1, Y + height - 4, width - 2, 3);
+    hitBoxComponents.add(topBox);
+    hitBoxComponents.add(btmBox);
 	}
 
 	/**

--- a/source/Player.hx
+++ b/source/Player.hx
@@ -33,6 +33,8 @@ import flixel.group.FlxGroup;
   public var topBox:FlxObject;
   public var btmBox:FlxObject;
 
+  private var hitBoxHeight:Int = 3;
+
 	/**
 	 * Intializer
 	 *
@@ -59,8 +61,8 @@ import flixel.group.FlxGroup;
 
     // Multiple hitbox support
     hitBoxComponents = new FlxTypedGroup<FlxObject>(2);
-    topBox = new FlxObject(X + 1, Y, width - 2, 3);
-    btmBox = new FlxObject(X + 1, Y + height - 4, width - 2, 3);
+    topBox = new FlxObject(X, Y, width, hitBoxHeight);
+    btmBox = new FlxObject(X, Y + height - hitBoxHeight, width, hitBoxHeight);
     hitBoxComponents.add(topBox);
     hitBoxComponents.add(btmBox);
 	}
@@ -147,15 +149,14 @@ import flixel.group.FlxGroup;
     return FlxG.keys.anyPressed([FlxKey.Z]);
   }
 
+  /**
+   * This method is called during every Player update cycle
+   * to keep the hitboxes in the same position relative to the player
+   */
   private function updateHitBoxes():Void
   {
-    var hitBoxHeight = 3;
-    var hitBoxOffset = 1;
-    var hitBoxWidth = width - hitBoxOffset * 2;
-    var hitBoxX = x + hitBoxOffset;
-
-    topBox.x = btmBox.x = hitBoxX;
-    topBox.y = y + hitBoxOffset;
-    btmBox.y = y + height - hitBoxOffset - hitBoxHeight;
+    topBox.x = btmBox.x = x;
+    topBox.y = y;
+    btmBox.y = y + height - hitBoxHeight;
   }
 }

--- a/source/Player.hx
+++ b/source/Player.hx
@@ -11,6 +11,7 @@ import flixel.FlxSprite;
 import flixel.system.FlxAssets.FlxGraphicAsset;
 import flixel.util.FlxColor;
 import flixel.input.keyboard.FlxKey;
+import flixel.group.FlxGroup;
 
 /**
  * ...
@@ -28,6 +29,10 @@ import flixel.input.keyboard.FlxKey;
 
 	public var xSlowdown:Float = 600;
 
+  public var hitBoxComponents:FlxTypedGroup<FlxObject>;
+  public var topBox:FlxObject;
+  public var btmBox:FlxObject;
+
 	/**
 	 * Intializer
 	 *
@@ -38,6 +43,13 @@ import flixel.input.keyboard.FlxKey;
 	public function new(?X:Float=0, ?Y:Float=0, ?SimpleGraphic:FlxGraphicAsset)
 	{
 		super(X, Y, SimpleGraphic);
+
+    // Multiple hitbox support
+    hitBoxComponents = new FlxTypedGroup<FlxObject>(2);
+    topBox = new FlxObject(X + 1, Y, width - 2, 3);
+    btmBox = new FlxObject(X + 1, Y + height - 4, width - 2, 3);
+    hitBoxComponents.add(topBox);
+    hitBoxComponents.add(btmBox);
 
 		// Initializes a basic graphic for the player
 		makeGraphic(32, 32, FlxColor.ORANGE);
@@ -78,6 +90,7 @@ import flixel.input.keyboard.FlxKey;
 	{
 		brain.update(this);
 		super.update(elapsed);
+    updateHitBoxes();
 	}
 
   /**
@@ -132,5 +145,17 @@ import flixel.input.keyboard.FlxKey;
   public function isRunning():Bool
   {
     return FlxG.keys.anyPressed([FlxKey.Z]);
+  }
+
+  private function updateHitBoxes():Void
+  {
+    var hitBoxHeight = 3;
+    var hitBoxOffset = 1;
+    var hitBoxWidth = width - hitBoxOffset * 2;
+    var hitBoxX = x + hitBoxOffset;
+
+    topBox.x = btmBox.x = hitBoxX;
+    topBox.y = y + hitBoxOffset;
+    btmBox.y = y + height - hitBoxOffset - hitBoxHeight;
   }
 }


### PR DESCRIPTION
Added two FlxObjects to serve as top and bottom hit-boxes for the player. We have tested in class using these to address some difficulties with colliding properly with blocks. Primarily, these will be of use to @Cortillaen 